### PR TITLE
适配微信8.0.21(2103)

### DIFF
--- a/rules/com.tencent.mm/8.0.21(2103).json
+++ b/rules/com.tencent.mm/8.0.21(2103).json
@@ -1,0 +1,19 @@
+{
+  "hookXWebPreferences": [
+    {
+      "name": "微信 XWeb 规则集 hookXWebPreferences",
+      "Class_XWebPreferences": "org.xwalk.core.XWalkPreferences",
+      "Method_setValue": "setValue"
+    }
+  ],
+  "hookWebViewClient": [
+    {
+      "name": "微信 XWeb 规则集 hookWebViewClient",
+      "Class_WebView": "com.tencent.xweb.WebView",
+      "Class_WebViewClient": "com.tencent.xweb.ah",
+      "Method_onPageFinished": "b",
+      "Method_evaluateJavascript": "evaluateJavascript",
+      "Class_ValueCallback": "android.webkit.ValueCallback"
+    }
+  ]
+}


### PR DESCRIPTION
8.0.21(2103)于Google Play的发布日期为2022年7月5日。

另：是否可以制作一份描述寻找注入点的方法文档？我只是根据其他几个微信版本的规律在apktool生成的smali里碰巧见到了好几处引用了`Lcom/tencent/xweb/ah`，配置进模块规则发现有效才确认的，之前没有逆向的经验😓